### PR TITLE
Remove spaces when open a ticket

### DIFF
--- a/js/background.js
+++ b/js/background.js
@@ -3,6 +3,7 @@ const _browser = this.browser || this.chrome;
 const storage = _browser.storage.sync || _browser.storage.local;
 
 var openTicket = (ticket, newTab) => {
+  ticket = ticket.replace(/%20/gi, '');
   storage.set({
     lastTicket: ticket
   });

--- a/js/background.js
+++ b/js/background.js
@@ -3,7 +3,7 @@ const _browser = this.browser || this.chrome;
 const storage = _browser.storage.sync || _browser.storage.local;
 
 var openTicket = (ticket, newTab) => {
-  ticket = ticket.replace(/%20/gi, '');
+  ticket = unescape(ticket).replace(/\s/g, ''),
   storage.set({
     lastTicket: ticket
   });


### PR DESCRIPTION
Sometimes, when I copy a ticket number I include spaces by mistake.

This is a quick solution to *fix* the URL, ticket numbers don't have spaces... in this scope, is `%20`