### PR TITLE
Support multiple jiras

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -131,6 +131,7 @@ li {
 
 input[type='text'].quiji-options-jira-url {
 	margin-top: 3px;
+	margin-bottom: 5px;
 	min-height: 2em;
 	padding-left: 6px;
 	width: 100%;

--- a/html/options.html
+++ b/html/options.html
@@ -29,7 +29,16 @@
 						>
 					</span>
 				</p>
-				<input type="text" class="quiji-options-jira-url" required />
+				<h3 data-i18n="companies"></h3>
+				<input type="text" class="quiji-options-jira-url" required placeholder="https://"/>
+				<input type="text" class="company-id" required placeholder="Unique ID or name" min="2"/>
+				<input type="text" class="quiji-options-jira-url" placeholder="https://"/>
+				<input type="text" class="company-id" placeholder="Unique ID or name" min="2"/>
+				<input type="text" class="quiji-options-jira-url" placeholder="https://"/>
+				<input type="text" class="company-id" placeholder="Unique ID or name" min="2"/>
+				<input type="text" class="quiji-options-jira-url" placeholder="https://"/>
+				<input type="text" class="company-id" placeholder="Unique ID or name" min="2"/>
+
 				<h3 data-i18n="defaultAction"></h3>
 				<p data-i18n="defaultActionDescription"></p>
 				<select name="default option">

--- a/html/options.html
+++ b/html/options.html
@@ -29,16 +29,16 @@
 						>
 					</span>
 				</p>
-				<input type="text" class="company-id" required data-i18n="baseURLMoreInfo" placeholder="ID" min="2"/>
+				<input type="text" class="company-id" required placeholder="ID"/>
 				<input type="text" class="quiji-options-jira-url" required placeholder="https://"/>
 				
-				<input type="text" class="company-id" placeholder="ID" min="2"/>
+				<input type="text" class="company-id" placeholder="ID"/>
 				<input type="text" class="quiji-options-jira-url" placeholder="https://"/>
 				
-				<input type="text" class="company-id" placeholder="ID" min="2"/>
+				<input type="text" class="company-id" placeholder="ID"/>
 				<input type="text" class="quiji-options-jira-url" placeholder="https://"/>
 				
-				<input type="text" class="company-id" placeholder="ID" min="2"/>
+				<input type="text" class="company-id" placeholder="ID"/>
 				<input type="text" class="quiji-options-jira-url" placeholder="https://"/>
 
 				<h3 data-i18n="defaultAction"></h3>

--- a/html/options.html
+++ b/html/options.html
@@ -29,15 +29,17 @@
 						>
 					</span>
 				</p>
-				<h3 data-i18n="companies"></h3>
+				<input type="text" class="company-id" required data-i18n="baseURLMoreInfo" placeholder="ID" min="2"/>
 				<input type="text" class="quiji-options-jira-url" required placeholder="https://"/>
-				<input type="text" class="company-id" required placeholder="Unique ID or name" min="2"/>
+				
+				<input type="text" class="company-id" placeholder="ID" min="2"/>
 				<input type="text" class="quiji-options-jira-url" placeholder="https://"/>
-				<input type="text" class="company-id" placeholder="Unique ID or name" min="2"/>
+				
+				<input type="text" class="company-id" placeholder="ID" min="2"/>
 				<input type="text" class="quiji-options-jira-url" placeholder="https://"/>
-				<input type="text" class="company-id" placeholder="Unique ID or name" min="2"/>
+				
+				<input type="text" class="company-id" placeholder="ID" min="2"/>
 				<input type="text" class="quiji-options-jira-url" placeholder="https://"/>
-				<input type="text" class="company-id" placeholder="Unique ID or name" min="2"/>
 
 				<h3 data-i18n="defaultAction"></h3>
 				<p data-i18n="defaultActionDescription"></p>

--- a/html/popup.html
+++ b/html/popup.html
@@ -12,10 +12,10 @@
 				<label>
 					<strong>Ticket ID</strong>
 					<select name="company" class="company-selector">
-						<option data-i18n="one" class="company-options" value="0"></option>
-						<option data-i18n="two" class="company-options" value="1"></option>
-						<option data-i18n="three" class="company-options" value="2"></option>
-						<option data-i18n="four" class="company-options" value="3"></option>
+						<option class="company-options" value="0"></option>
+						<option class="company-options" value="1"></option>
+						<option class="company-options" value="2"></option>
+						<option class="company-options" value="3"></option>
 					</select>
 					<input type="text" size="50" class="quiji-ticket-id" id="quiji-ticket-id" autofocus required />
 				</label>

--- a/html/popup.html
+++ b/html/popup.html
@@ -11,6 +11,12 @@
 			<p>
 				<label>
 					<strong>Ticket ID</strong>
+					<select name="company" class="company-selector">
+						<option data-i18n="one" class="company-options" value="0"></option>
+						<option data-i18n="two" class="company-options" value="1"></option>
+						<option data-i18n="three" class="company-options" value="2"></option>
+						<option data-i18n="four" class="company-options" value="3"></option>
+					</select>
 					<input type="text" size="50" class="quiji-ticket-id" id="quiji-ticket-id" autofocus required />
 				</label>
 			</p>

--- a/js/background.js
+++ b/js/background.js
@@ -9,7 +9,6 @@ var openTicket = (ticket, newTab, company) => {
 			trimSpaces: 0,
 		},
 		(options) => {
-			//const jiraURL = options && options.jiraURL;
 			const jiraUrlArray = parseInt(company)
 			const jiraURL = options && options.jiraURL[jiraUrlArray];
 

--- a/js/background.js
+++ b/js/background.js
@@ -2,14 +2,17 @@
 const _browser = this.browser || this.chrome;
 const storage = _browser.storage.sync || _browser.storage.local;
 
-var openTicket = (ticket, newTab) => {
+var openTicket = (ticket, newTab, company) => {
 	storage.get(
 		{
 			jiraURL: '',
 			trimSpaces: 0,
 		},
 		(options) => {
-			const jiraURL = options && options.jiraURL;
+			//const jiraURL = options && options.jiraURL;
+			const jiraUrlArray = parseInt(company)
+			const jiraURL = options && options.jiraURL[jiraUrlArray];
+
 			const trimSpaces = options && options.trimSpaces !== 0;
 			let newURL;
 

--- a/js/options.js
+++ b/js/options.js
@@ -9,12 +9,10 @@ const saveOptions = (event) => {
 	const jira = document.querySelectorAll('.quiji-options-jira-url');
 	const jiraCompanies = document.querySelectorAll('.company-id');
 
-	let invalidUrl = Boolean
-	for (let i = 0; i < jira.length; i++) {
-		if (!urlPattern.test(jira[i].value)) {
+	let invalidUrl = false
+	for (const urls of jira) {
+		if (!urlPattern.test(urls.value)) {
 			invalidUrl = true
-		} else {
-			invalidUrl = false
 		}
 	}
 	if (invalidUrl) {
@@ -72,7 +70,6 @@ const restoreOptions = () => {
 				allLinkNodes[i].value = allJiraLinks[i] || ''
 				allCompanyNodes[i].value = options.jiraCompanyIds[i] || ''
 			}
-			//document.querySelector('.quiji-options-jira-url').value = (options && options.jiraURL[0]) || '';
 			// Map 0 to currentTab and 1 to newTab
 			let defaultOption = _browser.i18n.getMessage('currentTab');
 			if (options && options.defaultOption === 1) {

--- a/js/options.js
+++ b/js/options.js
@@ -11,10 +11,11 @@ const saveOptions = (event) => {
 
 	let invalidUrl = false
 	for (const urls of jira) {
-		if (!urlPattern.test(urls.value)) {
-			invalidUrl = true
+		if (urls.value) {
+			invalidUrl = !urlPattern.test(urls.value) ? true : invalidUrl
 		}
 	}
+
 	if (invalidUrl) {
 		status.textContent = _browser.i18n.getMessage('validURL');
 	} else {

--- a/js/options.js
+++ b/js/options.js
@@ -6,8 +6,18 @@ const storage = _browser.storage.sync || _browser.storage.local;
 const saveOptions = (event) => {
 	event.preventDefault();
 	const status = document.querySelector('.quiji-options-status');
-	const jira = document.querySelector('.quiji-options-jira-url').value;
-	if (!urlPattern.test(jira)) {
+	const jira = document.querySelectorAll('.quiji-options-jira-url');
+	const jiraCompanies = document.querySelectorAll('.company-id');
+
+	let invalidUrl = Boolean
+	for (let i = 0; i < jira.length; i++) {
+		if (!urlPattern.test(jira[i].value)) {
+			invalidUrl = true
+		} else {
+			invalidUrl = false
+		}
+	}
+	if (invalidUrl) {
 		status.textContent = _browser.i18n.getMessage('validURL');
 	} else {
 		let defaultOption = document.querySelector('select').value;
@@ -20,9 +30,17 @@ const saveOptions = (event) => {
 
 		const trimSpaces = document.querySelector('#trim-spaces').checked ? 1 : 0;
 
+		let allJira = []
+		let allJiraCompanies = []
+		for (let i = 0; i < jira.length; i++) {
+			allJira.push(jira[i].value)
+			allJiraCompanies.push(jiraCompanies[i].value)
+		}
+
 		storage.set(
 			{
-				jiraURL: jira,
+				jiraURL: allJira,
+				jiraCompanyIds: allJiraCompanies,
 				defaultOption,
 				trimSpaces,
 			},
@@ -41,11 +59,20 @@ const restoreOptions = () => {
 	storage.get(
 		{
 			jiraURL: '',
+			jiraCompanyIds: '',
 			defaultOption: 0,
 			trimSpaces: 0,
 		},
 		(options) => {
-			document.querySelector('.quiji-options-jira-url').value = (options && options.jiraURL) || '';
+			//for each load options here. 
+			let allJiraLinks = options.jiraURL
+			let allLinkNodes = document.querySelectorAll('.quiji-options-jira-url')
+			let allCompanyNodes = document.querySelectorAll('.company-id')
+			for (let i = 0; i < allJiraLinks.length; i++) {
+				allLinkNodes[i].value = allJiraLinks[i] || ''
+				allCompanyNodes[i].value = options.jiraCompanyIds[i] || ''
+			}
+			//document.querySelector('.quiji-options-jira-url').value = (options && options.jiraURL[0]) || '';
 			// Map 0 to currentTab and 1 to newTab
 			let defaultOption = _browser.i18n.getMessage('currentTab');
 			if (options && options.defaultOption === 1) {

--- a/js/popup.js
+++ b/js/popup.js
@@ -12,6 +12,15 @@ const handleSubmit = (event) => {
 		window.setTimeout(() => window.close(), 1000);
 		_browser.extension.getBackgroundPage().openTicket(ticket, event.target.newTab, company);
 	}
+
+	storage.set(
+		{
+			jiraLASTCOMP: company,
+		},
+		() => {
+			//? maybe storing last option should be an option
+		}
+	);
 };
 
 const handleLastTicket = (event, defaultOption, lastTicket) => {
@@ -27,6 +36,7 @@ const renderDialog = () => {
 		{
 			defaultOption: 0,
 			jiraCompanyIds: '',
+			jiraLASTCOMP: '',
 			lastTicket: '',
 		},
 		(options) => {
@@ -42,6 +52,11 @@ const renderDialog = () => {
 				allCompanyOptions[i].innerHTML = options.jiraCompanyIds[i] || ''
 			}
 
+			//on first run, options.jiraLASTCOMP may be null
+			if (options.jiraLASTCOMP){
+				const jiraCompany = parseInt(options.jiraLASTCOMP)
+				document.querySelectorAll('.company-options')[jiraCompany].setAttribute('selected', '')
+		    }
 			const lastTicketButton = createLastTicketButton(options);
 
 			form.addEventListener('submit', handleSubmit);

--- a/js/popup.js
+++ b/js/popup.js
@@ -8,7 +8,6 @@ const handleSubmit = (event) => {
 	}
 	const ticket = encodeURIComponent(document.querySelector('.quiji-ticket-id').value);
 	const company = document.querySelector('.company-selector').value
-console.log(company)
 	if (ticket) {
 		window.setTimeout(() => window.close(), 1000);
 		_browser.extension.getBackgroundPage().openTicket(ticket, event.target.newTab, company);

--- a/js/popup.js
+++ b/js/popup.js
@@ -7,9 +7,11 @@ const handleSubmit = (event) => {
 		event.preventDefault();
 	}
 	const ticket = encodeURIComponent(document.querySelector('.quiji-ticket-id').value);
+	const company = document.querySelector('.company-selector').value
+console.log(company)
 	if (ticket) {
 		window.setTimeout(() => window.close(), 1000);
-		_browser.extension.getBackgroundPage().openTicket(ticket, event.target.newTab);
+		_browser.extension.getBackgroundPage().openTicket(ticket, event.target.newTab, company);
 	}
 };
 
@@ -25,6 +27,7 @@ const renderDialog = () => {
 	storage.get(
 		{
 			defaultOption: 0,
+			jiraCompanyIds: '',
 			lastTicket: '',
 		},
 		(options) => {
@@ -33,6 +36,12 @@ const renderDialog = () => {
 			newButton.newTab = true;
 			const currentButton = document.querySelector('.quiji-current-tab');
 			currentButton.newTab = false;
+
+			//render company options
+			let allCompanyOptions = document.querySelectorAll('.company-options')
+			for (let i = 0; i < allCompanyOptions.length; i++) {
+				allCompanyOptions[i].innerHTML = options.jiraCompanyIds[i] || ''
+			}
 
 			const lastTicketButton = createLastTicketButton(options);
 

--- a/js/popup.js
+++ b/js/popup.js
@@ -8,16 +8,15 @@ const handleSubmit = (event) => {
 	}
 	const ticket = encodeURIComponent(document.querySelector('.quiji-ticket-id').value);
 	const company = document.querySelector('.company-selector').value
-	if (ticket) {
-		window.setTimeout(() => window.close(), 1000);
-		_browser.extension.getBackgroundPage().openTicket(ticket, event.target.newTab, company);
-	}
-
 	storage.set(
 		{
-			jiraLASTCOMP: company,
+			jiraLastUsed: company,
 		},
 		() => {
+			if (ticket) {
+				window.setTimeout(() => window.close(), 1000);
+				_browser.extension.getBackgroundPage().openTicket(ticket, event.target.newTab, company);
+			}
 			//? maybe storing last option should be an option
 		}
 	);
@@ -36,7 +35,7 @@ const renderDialog = () => {
 		{
 			defaultOption: 0,
 			jiraCompanyIds: '',
-			jiraLASTCOMP: '',
+			jiraLastUsed: '',
 			lastTicket: '',
 		},
 		(options) => {
@@ -49,12 +48,12 @@ const renderDialog = () => {
 			//render company options
 			let allCompanyOptions = document.querySelectorAll('.company-options')
 			for (let i = 0; i < allCompanyOptions.length; i++) {
-				allCompanyOptions[i].innerHTML = options.jiraCompanyIds[i] || ''
+				allCompanyOptions[i].innerHTML = options.jiraCompanyIds[i] || `Jira ${i+1}`
 			}
 
-			//on first run, options.jiraLASTCOMP may be null
-			if (options.jiraLASTCOMP){
-				const jiraCompany = parseInt(options.jiraLASTCOMP)
+			//on first run, options.jiraLastUsed may be null
+			if (options.jiraLastUsed){
+				const jiraCompany = parseInt(options.jiraLastUsed)
 				document.querySelectorAll('.company-options')[jiraCompany].setAttribute('selected', '')
 		    }
 			const lastTicketButton = createLastTicketButton(options);


### PR DESCRIPTION
Addresses https://github.com/timbru31/quickjira/issues/14 


### Changes
- Using @timbru31 idea on https://github.com/timbru31/quickjira/issues/14#issuecomment-303056508
    - It accepts 3 more url and id strings from options form: extendable by number value parsed to integers
    - It stores arrays of these jira urls and an array of unique id for each one
    - It saves last used jira link on `handleSubmit` 
    - It selects last used jira link on `renderDialog`
- I added some placeholders and other minor UI hints


### Others
- not sure if the name `company` is whats chosen
- Should autocomplete be turned off for the options input field..


![Screen Shot 2022-04-17 at 13 46 06](https://user-images.githubusercontent.com/11727537/163771304-162c16c2-5bf4-4a65-8a84-078d7933ff9a.png)
![Screen Shot 2022-04-17 at 13 48 07](https://user-images.githubusercontent.com/11727537/163771307-aa6239b0-cc96-4449-b79e-bb36fec95006.png)

I just found and loved this extension and needed this feature so I thought it'll be a good idea to help myself and all the other users on it. 
