### PR TITLE
Remove unused dependencies declared in  package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
 	"homepage": "https://github.com/timbru31/quickjira#readme",
 	"devDependencies": {
 		"@types/chrome": "^0.0.245",
-		"addons-linter": "^6.13.0",
 		"husky": "^8.0.3",
 		"lint-staged": "^14.0.1",
 		"prettier": "^2.8.8",


### PR DESCRIPTION
Hello,

I noticed that the `addons-linter` package declared in the package.json file is unused in the source files of the project. Removing unused dependencies has an impact on the number of CI build minutes that are consumed during CI due to bumpings of unused dependencies by bots. In fact, I noticed the commits, bumping versions of these unused dependencies made by the dependabot, and those commits consume a substantial amount of CI build time.
On the other hand, removing unused dependencies may reduce the number of pull requests needed to be reviewed by developers for such cases. Thus, I am creating this PR to remove those unused dependencies.
Thus, I am submitting this PR to suggest removing unused dependencies.